### PR TITLE
Replace git command with git2-rs library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ path = "src/main.rs"
 clap = { version = "4.0", features = ["derive"] }
 inquire = "0.7"
 tokio = { version = "1.0", features = ["full"] }
+git2 = "0.19"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use inquire::Select;
 use std::process::{exit, Command};
+use git2::Repository;
 
 #[derive(Parser)]
 #[command(name = "worktree-attach")]
@@ -20,28 +21,52 @@ impl std::fmt::Display for Worktree {
 }
 
 fn get_worktrees() -> Result<Vec<Worktree>, Box<dyn std::error::Error>> {
-    let output = Command::new("git").args(["worktree", "list"]).output()?;
-
-    if !output.status.success() {
-        eprintln!(
-            "Error getting worktrees: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-        exit(1);
-    }
-
-    let stdout = String::from_utf8(output.stdout)?;
+    // Open the repository from current directory
+    let repo = Repository::open_from_env()?;
     let mut worktrees = Vec::new();
 
-    for line in stdout.lines() {
-        let parts: Vec<&str> = line.split_whitespace().collect();
-        // NOTE: `git worktree list`` output like below:
-        // /path/to/worktree 1234567 [branch-name]
-        if parts.len() >= 3 {
-            let path = parts[0].to_string();
-            // let commit = parts[1].to_string(); // now unused
-            let branch = parts[2].trim_matches(['[', ']']).to_string();
-            worktrees.push(Worktree { path, branch });
+    // Get the main worktree (the repository itself)
+    let workdir = repo.workdir().ok_or("Repository has no working directory")?;
+    let head_ref = repo.head()?;
+    let main_branch = if head_ref.is_branch() {
+        head_ref.shorthand().unwrap_or("HEAD").to_string()
+    } else {
+        "HEAD".to_string()
+    };
+    
+    worktrees.push(Worktree {
+        path: workdir.to_string_lossy().to_string(),
+        branch: main_branch,
+    });
+
+    // Get additional worktrees
+    let worktree_list = repo.worktrees()?;
+    for name in worktree_list.iter() {
+        if let Some(name_str) = name {
+            if let Ok(worktree) = repo.find_worktree(name_str) {
+                if let Some(path) = worktree.path() {
+                    // Try to determine the branch for this worktree
+                    let branch_name = if let Ok(wt_repo) = Repository::open(path) {
+                        let head = wt_repo.head().ok();
+                        if let Some(head_ref) = head {
+                            if head_ref.is_branch() {
+                                head_ref.shorthand().unwrap_or(name_str).to_string()
+                            } else {
+                                name_str.to_string()
+                            }
+                        } else {
+                            name_str.to_string()
+                        }
+                    } else {
+                        name_str.to_string()
+                    };
+                    
+                    worktrees.push(Worktree {
+                        path: path.to_string_lossy().to_string(),
+                        branch: branch_name,
+                    });
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This PR replaces git command line usage with git2-rs library calls as requested in issue #2.

## Changes
- Add git2 dependency to Cargo.toml
- Replace `Command::new("git").args(["worktree", "list"])` with git2-rs API
- Update get_worktrees() to use Repository::open_from_env() and native git2 calls
- Maintain same functionality while removing dependency on git command line tool

Fixes #2

Generated with [Claude Code](https://claude.ai/code)